### PR TITLE
Ensure push to hub even if training interrupted

### DIFF
--- a/serverless/train.py
+++ b/serverless/train.py
@@ -345,9 +345,11 @@ def main():
 
     logger.info("Starting Full Model Training...")
 
-    trainer.train()
-    if not cfg["hpo_run"]:
-        trainer.push_to_hub()
+    try:
+        trainer.train()
+    finally:
+        if not cfg["hpo_run"]:
+            trainer.push_to_hub()
 
 
 

--- a/serverless/train_dpo.py
+++ b/serverless/train_dpo.py
@@ -357,13 +357,14 @@ def main():
 
     logger.info("Starting Full Model Training...")
 
-    trainer.train()
-
-    if not cfg["hpo_run"]:
-        trainer.model.save_pretrained(
-            cfg["output_dir"], safe_serialization=True
-        )
-        trainer.push_to_hub()
+    try:
+        trainer.train()
+    finally:
+        if not cfg["hpo_run"]:
+            trainer.model.save_pretrained(
+                cfg["output_dir"], safe_serialization=True
+            )
+            trainer.push_to_hub()
 
 
 

--- a/serverless/train_grpo.py
+++ b/serverless/train_grpo.py
@@ -383,9 +383,11 @@ def main():
 
     logger.info("Starting Full Model Training...")
 
-    trainer.train()
-    if not cfg["hpo_run"]:
-        trainer.push_to_hub()
+    try:
+        trainer.train()
+    finally:
+        if not cfg["hpo_run"]:
+            trainer.push_to_hub()
 
 
 


### PR DESCRIPTION
## Summary
- push to hub in all serverless training scripts even if `trainer.train()` exits early or raises an exception

## Testing
- `pytest -q validator/tests` *(fails: `pytest` command not found)*